### PR TITLE
Remove schore - no such icon

### DIFF
--- a/ui/src/components/icon-set/material-icons.js
+++ b/ui/src/components/icon-set/material-icons.js
@@ -769,7 +769,6 @@ export default {
     { name: 'scatter_plot', tags: ['editor'] },
     { name: 'schedule', tags: ['calendar'] },
     { name: 'school', tags: [] },
-    { name: 'schore', tags: ['sport'] },
     { name: 'score', tags: ['editor'] },
     { name: 'screen_lock_landscape', tags: [] },
     { name: 'screen_lock_portrait', tags: [] },


### PR DESCRIPTION
{ name: 'schore', tags: ['sport'] } -- no such icon in material-icons